### PR TITLE
Filter out name column from data

### DIFF
--- a/carsuite/baselines/torch/dim/train.py
+++ b/carsuite/baselines/torch/dim/train.py
@@ -130,7 +130,7 @@ def main(argv):
       The processed batch.
     """
     # Sends tensors to `device`.
-    batch = {key: tensor.to(device) for (key, tensor) in batch.items()}
+    batch = {key: tensor.to(device) for (key, tensor) in batch.items() if key != 'name'}
     # Preprocesses batch for the model.
     batch = model.transform(batch)
     return batch


### PR DESCRIPTION
Data might contain the column `name` which breaks the training loop. This change filters out the column.